### PR TITLE
feat(orc-3198): allow to assert entity with properties

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,7 +96,7 @@ jobs:
 
             - name: Run codecov
               uses: codecov/codecov-action@v1
-              if: matrix.coverage == 'xdebug' && matrix.php == '8.3' && matrix.symfony-versions == '^7.0'
+              if: matrix.coverage == 'xdebug'
               with:
                   file: './coverage.xml'
                   fail_ci_if_error: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,7 @@ jobs:
                 php:
                     - '8.1'
                     - '8.2'
+                    - '8.3'
                 coverage: ['none']
                 symfony-versions:
                     - '4.4.*'
@@ -95,7 +96,7 @@ jobs:
 
             - name: Run codecov
               uses: codecov/codecov-action@v1
-              if: matrix.coverage == 'xdebug'
+              if: matrix.coverage == 'xdebug' && matrix.php == '8.3' && matrix.symfony-versions == '^7.0'
               with:
                   file: './coverage.xml'
                   fail_ci_if_error: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,8 +95,9 @@ jobs:
               if: matrix.coverage == 'xdebug'
 
             - name: Run codecov
-              uses: codecov/codecov-action@v1
+              uses: codecov/codecov-action@v4.0.1
               if: matrix.coverage == 'xdebug'
               with:
+                  token: ${{ secrets.CODECOV_TOKEN }}
                   file: './coverage.xml'
                   fail_ci_if_error: true

--- a/src/Context/ORMContext.php
+++ b/src/Context/ORMContext.php
@@ -75,8 +75,8 @@ final class ORMContext implements Context
 
         if (null !== $params) {
             foreach ($params as $columnName => $columnValue) {
-                $query->andWhere("e.$columnName = :value$columnName")
-                    ->setParameter("value$columnName", $columnValue);
+                $query->andWhere(sprintf('e.%s = :%s', $columnName, $columnName))
+                    ->setParameter($columnName, $columnValue);
             }
         }
 

--- a/src/Context/ORMContext.php
+++ b/src/Context/ORMContext.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BehatApiContext\Context;
 
 use Behat\Behat\Context\Context;
+use Behat\Gherkin\Node\PyStringNode;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\NoResultException;
@@ -52,6 +53,15 @@ final class ORMContext implements Context
     }
 
     /**
+     * @Then I see entity :entity with properties:
+     */
+    public function andISeeEntityInRepositoryWithProperties(string $entityClass, PyStringNode $string): void
+    {
+        $expectedProperties = json_decode(trim($string->getRaw()), true, 512, JSON_THROW_ON_ERROR);
+        $this->seeInRepository(1, $entityClass, $expectedProperties);
+    }
+
+    /**
      * @param array<string, mixed> $params
      *
      * @throws NonUniqueResultException
@@ -65,7 +75,7 @@ final class ORMContext implements Context
 
         if (null !== $params) {
             foreach ($params as $columnName => $columnValue) {
-                $query->where("e.$columnName = :value$columnName")
+                $query->andWhere("e.$columnName = :value$columnName")
                     ->setParameter("value$columnName", $columnValue);
             }
         }


### PR DESCRIPTION
Add possibility to check that database has an entity with particular properties.
This will allow to verify that create/update endpoints with empty responses actually produced desired changes.

Example:
```
        When I send "POST" request to "some_route" route
        Then response status code should be 204
        #! success
        And response should be empty
        And I see entity "App\Domain\Entity\SomeEntity" with properties:
            """
            {
                "id": "11111111-1111-1111-1111-111111111111",
                "type": "someType",
                "status": "someStatus"
            }
            """
```