### PR TITLE
Release

### DIFF
--- a/src/Context/ApiContext.php
+++ b/src/Context/ApiContext.php
@@ -25,7 +25,7 @@ class ApiContext implements Context
     private RouterInterface $router;
     private RequestStack $requestStack;
     private Response $response;
-    private KernelInterface&TerminableInterface $kernel;
+    private KernelInterface $kernel;
 
     /**
      * @var list<ResetManagerInterface>
@@ -55,7 +55,7 @@ class ApiContext implements Context
     public function __construct(
         RouterInterface $router,
         RequestStack $requestStack,
-        KernelInterface&TerminableInterface $kernel
+        KernelInterface $kernel
     ) {
         $this->router = $router;
         $this->requestStack = $requestStack;
@@ -182,7 +182,10 @@ class ApiContext implements Context
         $response = $this->kernel->handle($request);
 
         $this->requestStack->pop();
-        $this->kernel->terminate($request, $response);
+
+        if ($this->kernel instanceof TerminableInterface) {
+            $this->kernel->terminate($request, $response);
+        }
 
         foreach ($this->resetManagers as $resetManager) {
             if ($resetManager->needsReset($request->getMethod())) {


### PR DESCRIPTION
This pull request updates the `ApiContext` class to improve compatibility and flexibility when working with different types of kernel implementations. The main change is to remove the strict requirement that the kernel must implement both `KernelInterface` and `TerminableInterface`, and instead check for `TerminableInterface` at runtime.